### PR TITLE
fix: add nofollow at filter links

### DIFF
--- a/components/search/Filters.tsx
+++ b/components/search/Filters.tsx
@@ -29,6 +29,7 @@ function ValueItem({
   return (
     <a
       href={url}
+      rel="nofollowß"
       class={`text-small ${
         selected
           ? "text-black border rounded-full px-3 py-1 inline-flex items-center gap-2 w-fit"


### PR DESCRIPTION
Adicionando nofollow nos links de filtros, pois a falta dele gera um looping dos bots rastreadores, acumulando em muitos requests nas páginas.